### PR TITLE
Issue103

### DIFF
--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -202,6 +202,7 @@ function saveChanges(makeBackup = true) {
 function cleanTree(tree:Document) {
   const all = tree.querySelectorAll('section, a');
   for (const e of all) {
+    if (e.classList.contains('flash')) e.classList.remove('flash');
     if (e.classList.length === 0) {
       e.removeAttribute('class');
     }


### PR DESCRIPTION
We added a line in the cleanTree function to remove the highlight before storing the HTML.

Fix #103 

Co-authored-by: @toto101230
