### PR TITLE
Issue 102

### DIFF
--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -262,6 +262,10 @@ function addLink() {
 
 function createPanel() {
   const div = cloneTemplateToTarget('#template_panel', els.main);
+  div.scrollIntoView({ behavior: 'smooth' });
+  toast.html('locked', '<h1>Add panel.</h1><p>You have added a panel. It is at the bottom.</p>');
+  div.classList.add('flash');
+  div.addEventListener('animationend', () => { div.classList.remove('flash'); });
   return div;
 }
 


### PR DESCRIPTION
Added highlight and scroll when we add a panel. 

We have not used the flash() function as it still uses a timeout whereas our solution uses an eventListenner activated at the end of the animation. A possible improvement would be to modify the function so that it uses an eventListener and then allow us to use it for both pannel and link addition.

The function flash solution : `window.setTimeout(() => { elem.classList.remove('flash'); }, 1000); `
Our solution : `  div.addEventListener('animationend', () => { div.classList.remove('flash'); });`


Fixes #102

Co-authored-by: @toto101230