### PR TITLE
Duplicate Trash Panels

### DIFF
--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -3,7 +3,7 @@ import { Options, OPTS } from './defaults.js';
 import * as toast from './toast.js';
 import * as tooltip from './tooltip.js';
 import * as util from './util.js';
-import { ColorSwitch } from 'color-switch/index.js';
+import { ColorSwitch } from './color-switch/index.js';
 
 
 export interface Elems {
@@ -206,6 +206,7 @@ function cleanTree(tree:Document) {
   const all = tree.querySelectorAll('section, a');
   for (const e of all) {
     if (e.classList.contains('flash')) e.classList.remove('flash');
+    if (e.classList.contains('highlight')) e.classList.remove('highlight');
     if (e.classList.length === 0) {
       e.removeAttribute('class');
     }
@@ -597,6 +598,7 @@ function dragDrop(e: DragEvent) {
   dragging.el.classList.remove('dragging');
   dragging.el.classList.remove('fresh');
   if (e.target === els.bin && !dragging.dummy) {
+    els.trash = els.main.querySelector('#trash') || cloneTemplateToTarget('#template_trash', els.main);
     els.trash.lastElementChild?.append(dragging.el);
     saveChanges();
     toast.html('locked', chrome.i18n.getMessage('locked_moved_to_trash'));
@@ -776,6 +778,7 @@ function prepareContent(html:string) {
 
 function toggleTrash() {
   // ensure trash is the last thing on the screen
+  els.trash = els.main.querySelector('#trash') || cloneTemplateToTarget('#template_trash', els.main);
   els.main.append(els.trash);
   els.trash.classList.toggle('open');
   if (els.trash.classList.contains('open')) {


### PR DESCRIPTION
We searched all day why the bug appears but we didn't find it. 
We've at least found a solution for it.

To reproduce the bug if someone wants to search why this appears: 
 - Click on trash in the sidebar
 - Add a link to the panel of trash
 - Drag something in it or just fly above it without dropping the elements into the trash.
 - When u click again on trash in the sidebar it's duplicated ( invisible at first click then it appear ).

We think that els.trash after dragging something are changed by one of the functions and so toggleTrash() appends another trash than the one that appeared at first ( it may be the one that is saved in the store ).

We also fixed a bug with highlight like #103 and a missed './'

Fixes #114

Co-authored-by: @toto101230