### PR TITLE
New Link/Panel should edit on drop issue 81

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -182,5 +182,8 @@
   },
   "return_index": {
     "message": "Return"
+  },
+  "editOnNewDrop": {
+    "message": "Open edit dialogue after create and drop new panel/link"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -185,5 +185,8 @@
   },
   "return_index": {
     "message": "Retour"
+  },
+  "editOnNewDrop": {
+    "message": "Ouvrez le dialogue d'édition après avoir créé et déposé un nouveau panneau/lien."
   }
 }

--- a/src/js/defaults.ts
+++ b/src/js/defaults.ts
@@ -16,6 +16,7 @@ export interface BooleanOpts {
   showBookmarksSidebar: boolean,
   hideBookmarksInPage: boolean,
   useCustomScrollbar: boolean,
+  editOnNewDrop: boolean,
 }
 
 export interface StringOpts {
@@ -44,6 +45,7 @@ export const OPTS: Options = {
   showBookmarksSidebar: true,
   showToolTips: true,
   useCustomScrollbar: true,
+  editOnNewDrop: true,
 
   // StringOpts
   storage: 'local',

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -91,10 +91,12 @@ function editStart(elem:HTMLElement) {
     cloneToDialog('#template_edit_link');
     setValue('#editname', elem.textContent);
     setValue('#editurl', elem.href);
+    (document.querySelector('#editname') as HTMLInputElement).select();
   } else {
     if (elem.tagName === 'SECTION') {
       cloneToDialog('#template_edit_panel');
       setValue('#editname', elem.firstElementChild!.textContent);
+      (document.querySelector('#editname') as HTMLInputElement).select();
     } else {
       return;
     }

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -475,12 +475,14 @@ function dragStart(e:DragEvent) {
     if (target.id === 'addlink') {
       dummy = createExampleLink();
       dummy.classList.add('dragging');
+      dummy.classList.add('new');
       el = dummy;
       toast.html('addlink', chrome.i18n.getMessage('add_link'));
     } else {
       // addpanel
       dummy = createPanel();
       dummy.classList.add('dragging');
+      dummy.classList.add('new');
       el = dummy;
       toast.html('addpanel', chrome.i18n.getMessage('add_panel'));
     }
@@ -607,6 +609,10 @@ function dragDrop(e: DragEvent) {
       extractDataFromDrop(e);
     }
     // handle all cases
+    if (dragging.el.classList.contains('new')) {
+      dragging.el.classList.remove('new');
+      if (OPTS.editOnNewDrop) editStart(dragging.el);
+    }
     saveChanges();
   }
 }

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -60,6 +60,7 @@ function updatePrefsWithPage() {
   getCheckBox('showToolTips');
   getCheckBox('proportionalSections');
   getCheckBox('useCustomScrollbar');
+  getCheckBox('editOnNewDrop');
   getValue('showToast');
   getValue('showBookmarksLimit');
   getValue('space');
@@ -73,6 +74,7 @@ function updatePageWithPrefs(prefs:Options) {
   setCheckBox(prefs, 'showToolTips');
   setCheckBox(prefs, 'proportionalSections');
   setCheckBox(prefs, 'useCustomScrollbar');
+  setCheckBox(prefs, 'editOnNewDrop');
   setValue(prefs, 'showToast');
   setValue(prefs, 'showBookmarksLimit');
   setValue(prefs, 'space');
@@ -147,6 +149,7 @@ function createPageWithPrefs(prefs:Options) {
     create(layout, 'range', { id: 'space', max: '200', min: '0', step: '5' }, chrome.i18n.getMessage('space'));
     create(layout, 'range', { id: 'fontsize', max: '150', min: '50', step: '10' }, chrome.i18n.getMessage('fontsize'));
     create(layout, 'checkbox', { id: 'useCustomScrollbar' }, chrome.i18n.getMessage('useCustomScrollbar'));
+    create(layout, 'checkbox', { id: 'editOnNewDrop' }, chrome.i18n.getMessage('editOnNewDrop'));
   }
   updatePageWithPrefs(prefs);
 }


### PR DESCRIPTION
When dropping a new link/panel, the editing window opens if the option is selected.

Fixes #81

Co-authored-by: @YassineSMR