### PR TITLE
Top sites panel improvement - Issue126

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -42,7 +42,7 @@
 
 <template id=template_panel>
   <section draggable=true>
-    <h1 data-locale="panel">Panel</h1>
+    <h1>Panel</h1>
     <nav></nav>
   </section>
 </template>

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -268,6 +268,7 @@ function addLink() {
 
 function createPanel() {
   const div = cloneTemplateToTarget('#template_panel', els.main);
+  div.firstElementChild!.textContent = chrome.i18n.getMessage('panel');
   div.scrollIntoView({ behavior: 'smooth' });
   toast.html('locked', chrome.i18n.getMessage('add_panel_auto'));
   div.classList.add('flash');
@@ -284,8 +285,29 @@ function addPanel() {
 }
 
 function addTopSitesPanel() {
-  const panel = createPanel();
-  panel.firstElementChild!.innerHTML = chrome.i18n.getMessage('top_sites_panel');
+  let panel = els.main.querySelector('#topsites');
+  if (!panel) {
+    panel = createPanel();
+    panel.id = 'topsites';
+    panel.firstElementChild!.textContent = chrome.i18n.getMessage('top_sites_panel');
+  }
+  updateTopSites();
+  let e = panel.parentElement;
+  while (e && e !== els.main) {
+    if (e.classList.contains('folded')) e.classList.toggle('folded');
+    e = e.parentElement;
+  }
+  panel.scrollIntoView({ behavior: 'smooth' });
+  flash(panel as HTMLElement, 'highlight');
+}
+
+function updateTopSites() {
+  const panel = els.main.querySelector('#topsites');
+  if (!panel) return;
+  const sites = panel.querySelectorAll('a');
+  for (const link of sites) {
+    panel.lastElementChild?.removeChild(link);
+  }
   chrome.topSites.get((data) => {
     for (const link of data) {
       const a = createExampleLink(link.title, link.url);
@@ -960,6 +982,7 @@ async function prepareAll() {
   toast.popup(chrome.i18n.getMessage('popup_toggle_sidebar'));
   tooltip.prepare(OPTS);
   migrateLinks();
+  updateTopSites();
   util.localizeHtml(document);
 }
 

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -292,6 +292,7 @@ function addTopSitesPanel() {
     panel.firstElementChild!.textContent = chrome.i18n.getMessage('top_sites_panel');
   }
   updateTopSites();
+  if (panel.classList.contains('folded')) panel.classList.toggle('folded');
   let e = panel.parentElement;
   while (e && e !== els.main) {
     if (e.classList.contains('folded')) e.classList.toggle('folded');


### PR DESCRIPTION
Fix #126 : 
- [x] Only one top sites panels per page
- [x] If there is one top site panel on the start tab, scroll to it and open every section where he is hidden, and flash the panel.
- [x] The panel update at every launch

We also fixed some minors bugs we found.

Co-authored: @toto101230 