### PR TITLE
Two new Options for Locked page - Issue 97

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -199,6 +199,12 @@
     "message": "Reset"
   },
   "suggest_backup": {
-    "message": "Do u want to make a backup ?"
+    "message": "Do you want to make a backup ?"
+  },
+  "allow_collapsing_locked": {
+    "message": "Allow collapsing and opening of panels when page is locked"
+  },
+  "save_panel_status_locked": {
+    "message": "Remember status of panel (open/collapsed) when the page is locked"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -203,5 +203,11 @@
   },
   "suggest_backup": {
     "message": "Voulez-vous faire une sauvegarde ?"
+  },
+  "allow_collapsing_locked": {
+    "message": "Autoriser la fermeture et l'ouverture de panneaux quand la page est verrouiller"
+  },
+  "save_panel_status_locked": {
+    "message": "Se souvenir du statut du panneau (ouvert/fermer) quand la page est verrouiller"
   }
 }

--- a/src/js/defaults.ts
+++ b/src/js/defaults.ts
@@ -17,6 +17,8 @@ export interface BooleanOpts {
   hideBookmarksInPage: boolean,
   useCustomScrollbar: boolean,
   editOnNewDrop: boolean,
+  allowCollapsingLocked: boolean,
+  savePanelStatusLocked: boolean,
 }
 
 export interface StringOpts {
@@ -44,6 +46,8 @@ export const OPTS: Options = {
   showToolTips: true,
   useCustomScrollbar: true,
   editOnNewDrop: true,
+  allowCollapsingLocked: true,
+  savePanelStatusLocked: false,
 
   // StringOpts
   backup: '',

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -737,6 +737,10 @@ function findParentSection(elem?:Element) {
 }
 
 function toggleFold(e:Event) {
+  if (!OPTS.allowCollapsingLocked) {
+    toast.html('locked', chrome.i18n.getMessage('locked'));
+    return;
+  }
   if (!(e.target instanceof HTMLElement)) return;
   if (els.body.classList.contains('editing')) return;
   const foldMe = findParentSection(e.target);
@@ -748,7 +752,7 @@ function toggleFold(e:Event) {
   }
   if (foldMe?.tagName === 'SECTION') {
     foldMe.classList.toggle('folded');
-    saveChanges();
+    if (OPTS.savePanelStatusLocked) saveChanges();
   }
   prepareDynamicFlex(els.main);
 }

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -42,6 +42,8 @@ export function loadOptionsWithPromise() :Promise<void> {
 // the OPTS object that gets stored.
 function updatePrefsWithPage() {
   getCheckBox('lock');
+  getCheckBox('allowCollapsingLocked');
+  getCheckBox('savePanelStatusLocked');
   getCheckBox('showBookmarksSidebar');
   getCheckBox('hideBookmarksInPage');
   getCheckBox('showToolTips');
@@ -56,6 +58,8 @@ function updatePrefsWithPage() {
 
 function updatePageWithPrefs(prefs:Options) {
   setCheckBox(prefs, 'lock');
+  setCheckBox(prefs, 'allowCollapsingLocked');
+  setCheckBox(prefs, 'savePanelStatusLocked');
   setCheckBox(prefs, 'showBookmarksSidebar');
   setCheckBox(prefs, 'hideBookmarksInPage');
   setCheckBox(prefs, 'showToolTips');
@@ -132,6 +136,8 @@ function createPageWithPrefs(prefs:Options) {
     create(feed, 'checkbox', { id: 'showToolTips' }, chrome.i18n.getMessage('showToolTips'));
     create(feed, 'number', { id: 'showToast' }, chrome.i18n.getMessage('showToast'));
     create(layout, 'checkbox', { id: 'lock' }, chrome.i18n.getMessage('lock'));
+    create(layout, 'checkbox', { id: 'allowCollapsingLocked' }, chrome.i18n.getMessage('allow_collapsing_locked'));
+    create(layout, 'checkbox', { id: 'savePanelStatusLocked' }, chrome.i18n.getMessage('save_panel_status_locked'));
     create(layout, 'checkbox', { id: 'proportionalSections' }, chrome.i18n.getMessage('proportionalSections'));
     create(layout, 'range', { id: 'space', max: '200', min: '0', step: '5' }, chrome.i18n.getMessage('space'));
     create(layout, 'range', { id: 'fontsize', max: '150', min: '50', step: '10' }, chrome.i18n.getMessage('fontsize'));


### PR DESCRIPTION
The first one allows collapsing panel when the page is locked.
And the second one allows the user to choose if the status of the panel should be saved when the page is locked

Fixes #97

Co-authored: @toto101230