### PR TITLE
Prevent edit on elements inside of nav

### DIFF
--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -97,6 +97,9 @@ function translateColor(rgba:string) {
 function editStart(elem:HTMLElement) {
   els.edit.textContent = ''; // reset
   const style = window.getComputedStyle(elem);
+  if (elem.parentElement?.id === 'toolbarnav') {
+    return;
+  }
   if (elem instanceof HTMLAnchorElement) {
     cloneToDialog('#template_edit_link');
     setValue('#editname', elem.textContent);


### PR DESCRIPTION
When playing fast and loose with the layout of the page, it's possible to shift+click on the elements inside of the nav and mistakenly or unintentionally create edits to the elements in the nav. A new tab is a workaround but this mitigates the problem.

The check relies on the parent element having the id `toolbarnav` which creates a coupling to the name of the element so would be happy to change if requested to something more solid but since the name is unlikely to change I think this is okay.

Before:
![before](https://user-images.githubusercontent.com/25016090/146696309-b6e3614a-3200-4a61-be8b-230de8026936.gif)

After:
![after](https://user-images.githubusercontent.com/25016090/146696315-6392b02f-048a-48a8-92bb-3e5035c99941.gif)