### PR TITLE
local storage data migration

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "name": "Structured Start Tab",
   "description": "Show a structured page when a new tab is opened.",
   "author": "Rich Boakes",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "structured-start-tab",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Structured Start Tab",
   "author": "Rich Boakes <rich@boakes.org>",
   "contributors": [

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -77,27 +77,12 @@ function menuClicked(info, tab) {
     chrome.tabs.sendMessage(tab.id, { item: info.menuItemId });
   }
 }
-function menuInstaller(details) {
+function menuInstaller() {
   const indexURL = chrome.runtime.getURL('app/index.html');
   for (const menuItem of menuItems) {
     menuItem.documentUrlPatterns = [indexURL];
     menuItem.contexts = ['page', 'link'];
     chrome.contextMenus.create(menuItem);
-  }
-  if (details.reason === 'update') {
-    chrome.storage.local.get(null, items => {
-      if (chrome.runtime.lastError) {
-        console.error('cannot get the data');
-      } else {
-        if (Object.keys(items).length !== 0) {
-          const importLastConfig = confirm(chrome.i18n.getMessage('import_config'));
-          if (importLastConfig) {
-            localStorage.setItem('structured-start-tab', JSON.stringify(items));
-          }
-        }
-      }
-    });
-    chrome.storage.local.clear();
   }
   chrome.alarms.create('agendaUpdate', {
     periodInMinutes: 15,

--- a/src/js/lib/options.js
+++ b/src/js/lib/options.js
@@ -39,6 +39,7 @@ export function load() {
       // Migrate data from localStorage to chrome.storage.local
       if (migratedData == null && currentData != null) {
         migratedData = JSON.parse(currentData);
+        Object.assign(OPTS, migratedData);
         write();
       }
 

--- a/src/js/lib/options.js
+++ b/src/js/lib/options.js
@@ -33,7 +33,7 @@ const settingKey = 'structured-start-tab';
 export function load() {
   return new Promise(resolve => {
     const currentData = localStorage.getItem(settingKey);
-    chrome.storage.local.get([settingKey], function (result) {
+    chrome.storage.local.get([settingKey], (result) => {
       let migratedData = result[settingKey];
 
       // Migrate data from localStorage to chrome.storage.local
@@ -50,8 +50,8 @@ export function load() {
 }
 export function write() {
   return new Promise(resolve => {
-    chrome.storage.local.set({ [settingKey]: OPTS }, function (result) {
-      resolve(result[settingKey]);
+    chrome.storage.local.set({ [settingKey]: OPTS }, () => {
+      resolve();
     });
   });
 }

--- a/src/js/lib/options.js
+++ b/src/js/lib/options.js
@@ -27,15 +27,30 @@ export const OPTS = {
   linkStats: {},
   agendas: [],
 };
+
+const settingKey = 'structured-start-tab';
+
 export function load() {
-  const dataAsString = localStorage.getItem('structured-start-tab');
-  if (dataAsString) {
-    const data = JSON.parse(dataAsString);
-    Object.assign(OPTS, data);
-  }
-  return Promise.resolve();
+  return new Promise(resolve => {
+    const currentData = localStorage.getItem(settingKey);
+    chrome.storage.local.get([settingKey], function (result) {
+      let migratedData = result[settingKey];
+
+      // Migrate data from localStorage to chrome.storage.local
+      if (migratedData == null && currentData != null) {
+        migratedData = JSON.parse(currentData);
+        write();
+      }
+
+      Object.assign(OPTS, migratedData);
+      resolve();
+    });
+  });
 }
 export function write() {
-  localStorage.setItem('structured-start-tab', JSON.stringify(OPTS));
-  return Promise.resolve();
+  return new Promise(resolve => {
+    chrome.storage.local.set({ [settingKey]: OPTS }, function (result) {
+      resolve(result[settingKey]);
+    });
+  });
 }

--- a/src/js/options-page.js
+++ b/src/js/options-page.js
@@ -21,16 +21,6 @@ function getValue(what) {
   const elem = document.getElementById(what);
   OPTS[what] = elem.valueAsNumber;
 }
-export function loadOptionsWithPromise() {
-  return new Promise((resolve) => {
-    const dataAsString = localStorage.getItem('structured-start-tab');
-    if (dataAsString) {
-      const data = JSON.parse(dataAsString);
-      Object.assign(OPTS, data);
-    }
-    resolve();
-  });
-}
 // incorporate the latest values of the page into
 // the OPTS object that gets stored.
 function updatePrefsWithPage() {


### PR DESCRIPTION
Note: removed the `update` check on `menuInstaller` to prevent data from being cleared.
Also, looks like this method is no longer needed as it is performing the opposite action of what is needed.

Removing `loadOptionsWithPromise` as it is not used anywhere else.