### PR TITLE
Migrate to manifest v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "manifest_version": 2,
-  "version": "1.9.0",
+  "manifest_version": 3,
+  "version": "1.10.0",
   "name": "Structured Start Tab",
   "description": "Show a structured page when a new tab is opened.",
   "author": "Rich Boakes",
@@ -9,15 +9,17 @@
     "tabs",
     "storage",
     "bookmarks",
-    "chrome://favicon/",
+    "favicon",
     "contextMenus",
     "topSites",
-    "https://calendar.google.com/calendar/*",
     "alarms"
   ],
+  "host_permissions": [
+    "https://calendar.google.com/calendar/*"
+  ],
   "background": {
-    "persistent": false,
-    "page": "app/background.html"
+    "service_worker": "app/js/background.js",
+    "type": "module"
   },
   "icons": {
     "16": "app/style/i/16.png",
@@ -26,7 +28,7 @@
     "128": "app/style/i/128.png",
     "580": "app/style/i/580.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "app/style/i/48.png"
   },
   "chrome_url_overrides": {
@@ -36,8 +38,15 @@
     "page": "app/options-page.html"
   },
   "web_accessible_resources": [
-    "data/*",
-    "chrome://settings/strings.js"
+    {
+      "resources": [
+        "data/*",
+        "chrome://settings/strings.js"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
   ],
   "commands": {
     "toggle-sidebar": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.10.0",
+  "version": "1.9.1",
   "name": "Structured Start Tab",
   "description": "Show a structured page when a new tab is opened.",
   "author": "Rich Boakes",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -136,7 +136,7 @@ function setFavicon(elem, url) {
     elem.prepend(favicon);
   }
 
-  favicon.src = `chrome-extension://${chrome.runtime.id}/_favicon/?pageUrl=${encodeURIComponent(url)}&size=32`;
+  if (url) { favicon.src = `chrome-extension://${chrome.runtime.id}/_favicon/?pageUrl=${encodeURIComponent(url)}&size=32`; }
 }
 function prepareFavicons() {
   const links = els.main.querySelectorAll('a');

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -135,7 +135,8 @@ function setFavicon(elem, url) {
     favicon.className = 'favicon';
     elem.prepend(favicon);
   }
-  favicon.src = 'chrome://favicon/' + url;
+
+  favicon.src = `chrome-extension://${chrome.runtime.id}/_favicon/?pageUrl=${encodeURIComponent(url)}&size=32`;
 }
 function prepareFavicons() {
   const links = els.main.querySelectorAll('a');

--- a/src/js/lib/options.js
+++ b/src/js/lib/options.js
@@ -32,18 +32,8 @@ const settingKey = 'structured-start-tab';
 
 export function load() {
   return new Promise(resolve => {
-    const currentData = localStorage.getItem(settingKey);
     chrome.storage.local.get([settingKey], (result) => {
-      let migratedData = result[settingKey];
-
-      // Migrate data from localStorage to chrome.storage.local
-      if (migratedData == null && currentData != null) {
-        migratedData = JSON.parse(currentData);
-        Object.assign(OPTS, migratedData);
-        write();
-      }
-
-      Object.assign(OPTS, migratedData);
+      Object.assign(OPTS, result[settingKey]);
       resolve();
     });
   });


### PR DESCRIPTION
Important note: this will most likely cause incompatibility with Firefox as many features implemented by Chrome in MV3 are not supported or have been implemented differently in Firefox.

The extension will need to be ported to Firefox ([migration guide](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/)).