### PR TITLE
Versioning

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "version": "1.11.0.1",
   "version_name": "1.11.0-beta",
   "name": "Structured Start Tab (Beta)",
-  "description": "Show a structured page when a new tab is opened. (beta)",
+  "description": "Show a structured page when a new tab is opened.",
   "author": "Rich Boakes",
   "default_locale": "en",
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
   "manifest_version": 3,
   "version": "1.11.0.1",
+  "version_name": "1.11.0-beta",
   "name": "Structured Start Tab (Beta)",
   "description": "Show a structured page when a new tab is opened. (beta)",
   "author": "Rich Boakes",
@@ -74,6 +75,5 @@
       },
       "description": "Toggle presentation mode"
     }
-  },
-  "version_name": "1.11.0-beta"
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.11.0.0",
+  "version": "1.11.0.1",
   "name": "Structured Start Tab (Beta)",
   "description": "Show a structured page when a new tab is opened. (beta)",
   "author": "Rich Boakes",
@@ -74,5 +74,6 @@
       },
       "description": "Toggle presentation mode"
     }
-  }
+  },
+  "version_name": "1.11.0-beta"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "structured-start-tab-beta",
-  "version": "1.11.0.0",
+  "version": "1.11.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "structured-start-tab-beta",
-      "version": "1.11.0.0",
+      "version": "1.11.0-beta",
       "license": "MPL-2.0",
       "dependencies": {
         "firebase-admin": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "structured-start-tab-beta",
-  "version": "1.11.0.0",
+  "version": "1.11.0-beta",
   "description": "Structured Start Tab (beta)",
   "author": "Rich Boakes <rich@boakes.org>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "zip": "rm sst.zip;rm sst.xpi;find . -name '.DS_Store' -type f -delete;zip -u -8 -v -r sst.zip src _locales manifest.json release.md;cp sst.zip sst.xpi;echo 'bump versions in releases.md, manifest.json and package.json...'",
     "all": "npm run validatelogs;npm run zip;",
     "preversion": "npm run lint",
-    "version": "node update-manifest-version.js; git add manifest.json package.json;",
+    "version": "node update-manifest-version.js; git add .;",
     "postversion": "npm run all",
     "validatelogs": "if grep -qr 'console.log' src/; then echo 'WARNING: console.log were left in the code!'; fi"
   },

--- a/update-manifest-version.js
+++ b/update-manifest-version.js
@@ -23,8 +23,6 @@ manData.version = version;
 manData.version_name = version;
 manData.name = pkgData.description;
 
-// Version info
-
 // Add beta definitions
 if (type === 'beta') { // beta version should end with -beta
   // package details

--- a/update-manifest-version.js
+++ b/update-manifest-version.js
@@ -14,17 +14,27 @@ const manData = JSON.parse(manRaw);
 const htmlRaw = readFileSync(htmlPath, 'utf8');
 
 // Defaults
-manData.version = pkgData.version;
 pkgData.name = 'structured-start-tab';
 pkgData.description = 'Structured Start Tab';
 let pageTitle = 'Structured Start Tab';
 
+const [version, type] = pkgData.version.split('-');
+manData.version = version;
+manData.version_name = version;
+manData.name = pkgData.description;
+
+// Version info
+
 // Add beta definitions
-if (pkgData.version.split('.').length > 3) { // beta version should be structured as X.Y.Z.B whilst release version is X.Y.Z
+if (type === 'beta') { // beta version should end with -beta
+  // package details
   pkgData.name += '-beta';
-  manData.name += manData.name.endsWith(' (Beta)') ? '' : ' (Beta)';
   pkgData.description += ' (beta)';
-  manData.description += manData.description.endsWith(' (beta)') ? '' : ' (beta)';
+
+  // manifest details
+  manData.version_name += '-beta';
+  manData.version = `${manData.version}.1`;
+  manData.name += manData.name.endsWith(' (Beta)') ? '' : ' (Beta)';
 
   pageTitle += ' (beta)';
 }


### PR DESCRIPTION
New command format to version app: 

- Prod: `npm version x.y.z`
- Beta: `npm version x.y.z-beta`  

When versioning a beta release, the extension manifest gets updated to `x.y.z.1` to force an update (only digits allowed in the actual version number), whilst the version name will be `x.y.z-beta`

Closes #254 